### PR TITLE
Adds support for getting single properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Some requests require to be done on a live hubspot portal, you can set the `HUBS
 ```
 HUBSPOT_ACCESS_TOKEN=xxxx
 HUBSPOT_PORTAL_ID=yyyy
+HUBSPOT_HAPI_KEY=zzzz
 ```
 
 To add a new test or update a VCR recording, run the test with the `VCR_RECORD_MODE`

--- a/lib/hubspot/company_properties.rb
+++ b/lib/hubspot/company_properties.rb
@@ -3,6 +3,8 @@ module Hubspot
 
     ALL_PROPERTIES_PATH  = "/properties/v1/companies/properties"
     ALL_GROUPS_PATH      = "/properties/v1/companies/groups"
+    GET_PROPERTY_PATH    = "/properties/v1/companies/properties/named/:property_name"
+    GET_GROUP_PATH       = "/properties/v1/companies/groups/named/:group_name"
     CREATE_PROPERTY_PATH = "/properties/v1/companies/properties"
     UPDATE_PROPERTY_PATH = "/properties/v1/companies/properties/named/:property_name"
     DELETE_PROPERTY_PATH = "/properties/v1/companies/properties/named/:property_name"
@@ -19,8 +21,16 @@ module Hubspot
         superclass.all(ALL_PROPERTIES_PATH, opts, filter)
       end
 
+      def get(property_name, opts={})
+        superclass.get(GET_PROPERTY_PATH, property_name, opts)
+      end
+
       def groups(opts={}, filter={})
         superclass.groups(ALL_GROUPS_PATH, opts, filter)
+      end
+
+      def get_group(group_name, opts={})
+        superclass.get_group(GET_GROUP_PATH, group_name, opts={})
       end
 
       def create!(params={})

--- a/lib/hubspot/company_properties.rb
+++ b/lib/hubspot/company_properties.rb
@@ -3,8 +3,8 @@ module Hubspot
 
     ALL_PROPERTIES_PATH  = "/properties/v1/companies/properties"
     ALL_GROUPS_PATH      = "/properties/v1/companies/groups"
-    GET_PROPERTY_PATH    = "/properties/v1/companies/properties/named/:property_name"
-    GET_GROUP_PATH       = "/properties/v1/companies/groups/named/:group_name"
+    PROPERTY_PATH        = "/properties/v1/companies/properties/named/:property_name"
+    GROUP_PATH           = "/properties/v1/companies/groups/named/:group_name"
     CREATE_PROPERTY_PATH = "/properties/v1/companies/properties"
     UPDATE_PROPERTY_PATH = "/properties/v1/companies/properties/named/:property_name"
     DELETE_PROPERTY_PATH = "/properties/v1/companies/properties/named/:property_name"
@@ -21,16 +21,16 @@ module Hubspot
         superclass.all(ALL_PROPERTIES_PATH, opts, filter)
       end
 
-      def get(property_name, opts={})
-        superclass.get(GET_PROPERTY_PATH, property_name, opts)
+      def find(property_name, opts={})
+        superclass.find(PROPERTY_PATH, property_name, opts)
       end
 
       def groups(opts={}, filter={})
         superclass.groups(ALL_GROUPS_PATH, opts, filter)
       end
 
-      def get_group(group_name, opts={})
-        superclass.get_group(GET_GROUP_PATH, group_name, opts={})
+      def find_group(group_name, opts={})
+        superclass.find_group(GROUP_PATH, group_name, opts={})
       end
 
       def create!(params={})

--- a/lib/hubspot/contact_properties.rb
+++ b/lib/hubspot/contact_properties.rb
@@ -3,6 +3,8 @@ module Hubspot
 
     ALL_PROPERTIES_PATH  = "/properties/v1/contacts/properties"
     ALL_GROUPS_PATH      = "/properties/v1/contacts/groups"
+    GET_PROPERTY_PATH    = "/properties/v1/contacts/properties/named/:property_name"
+    GET_GROUP_PATH       = "/properties/v1/contacts/groups/named/:group_name"
     CREATE_PROPERTY_PATH = "/properties/v1/contacts/properties"
     UPDATE_PROPERTY_PATH = "/properties/v1/contacts/properties/named/:property_name"
     DELETE_PROPERTY_PATH = "/properties/v1/contacts/properties/named/:property_name"
@@ -19,8 +21,16 @@ module Hubspot
         superclass.all(ALL_PROPERTIES_PATH, opts, filter)
       end
 
+      def get(property_name, opts={})
+        superclass.get(GET_PROPERTY_PATH, property_name, opts)
+      end
+
       def groups(opts={}, filter={})
         superclass.groups(ALL_GROUPS_PATH, opts, filter)
+      end
+
+      def get_group(group_name, opts={})
+        superclass.get_group(GET_GROUP_PATH, group_name, opts)
       end
 
       def create!(params={})

--- a/lib/hubspot/contact_properties.rb
+++ b/lib/hubspot/contact_properties.rb
@@ -3,8 +3,8 @@ module Hubspot
 
     ALL_PROPERTIES_PATH  = "/properties/v1/contacts/properties"
     ALL_GROUPS_PATH      = "/properties/v1/contacts/groups"
-    GET_PROPERTY_PATH    = "/properties/v1/contacts/properties/named/:property_name"
-    GET_GROUP_PATH       = "/properties/v1/contacts/groups/named/:group_name"
+    PROPERTY_PATH        = "/properties/v1/contacts/properties/named/:property_name"
+    GROUP_PATH           = "/properties/v1/contacts/groups/named/:group_name"
     CREATE_PROPERTY_PATH = "/properties/v1/contacts/properties"
     UPDATE_PROPERTY_PATH = "/properties/v1/contacts/properties/named/:property_name"
     DELETE_PROPERTY_PATH = "/properties/v1/contacts/properties/named/:property_name"
@@ -21,16 +21,16 @@ module Hubspot
         superclass.all(ALL_PROPERTIES_PATH, opts, filter)
       end
 
-      def get(property_name, opts={})
-        superclass.get(GET_PROPERTY_PATH, property_name, opts)
+      def find(property_name, opts={})
+        superclass.find(PROPERTY_PATH, property_name, opts)
       end
 
       def groups(opts={}, filter={})
         superclass.groups(ALL_GROUPS_PATH, opts, filter)
       end
 
-      def get_group(group_name, opts={})
-        superclass.get_group(GET_GROUP_PATH, group_name, opts)
+      def find_group(group_name, opts={})
+        superclass.find_group(GROUP_PATH, group_name, opts)
       end
 
       def create!(params={})

--- a/lib/hubspot/deal_properties.rb
+++ b/lib/hubspot/deal_properties.rb
@@ -3,8 +3,8 @@ module Hubspot
 
     ALL_PROPERTIES_PATH  = '/deals/v1/properties'
     ALL_GROUPS_PATH      = '/deals/v1/groups'
-    GET_PROPERTY_PATH    = '/properties/v1/deals/properties/named/:property_name'
-    GET_GROUP_PATH       = '/properties/v1/deals/groups/named/:group_name'
+    PROPERTY_PATH        = '/properties/v1/deals/properties/named/:property_name'
+    GROUP_PATH           = '/properties/v1/deals/groups/named/:group_name'
     CREATE_PROPERTY_PATH = '/deals/v1/properties/'
     UPDATE_PROPERTY_PATH = '/deals/v1/properties/named/:property_name'
     DELETE_PROPERTY_PATH = '/deals/v1/properties/named/:property_name'
@@ -21,16 +21,16 @@ module Hubspot
         superclass.all(ALL_PROPERTIES_PATH, opts, filter)
       end
 
-      def get(property_name, opts={})
-        superclass.get(GET_PROPERTY_PATH, property_name, opts)
+      def find(property_name, opts={})
+        superclass.find(PROPERTY_PATH, property_name, opts)
       end
 
       def groups(opts={}, filter={})
         superclass.groups(ALL_GROUPS_PATH, opts, filter)
       end
 
-      def get_group(group_name, opts={})
-        superclass.get_group(GET_GROUP_PATH, group_name, opts)
+      def find_group(group_name, opts={})
+        superclass.find_group(GROUP_PATH, group_name, opts)
       end
 
       def create!(params={})

--- a/lib/hubspot/deal_properties.rb
+++ b/lib/hubspot/deal_properties.rb
@@ -3,6 +3,8 @@ module Hubspot
 
     ALL_PROPERTIES_PATH  = '/deals/v1/properties'
     ALL_GROUPS_PATH      = '/deals/v1/groups'
+    GET_PROPERTY_PATH    = '/properties/v1/deals/properties/named/:property_name'
+    GET_GROUP_PATH       = '/properties/v1/deals/groups/named/:group_name'
     CREATE_PROPERTY_PATH = '/deals/v1/properties/'
     UPDATE_PROPERTY_PATH = '/deals/v1/properties/named/:property_name'
     DELETE_PROPERTY_PATH = '/deals/v1/properties/named/:property_name'
@@ -19,8 +21,16 @@ module Hubspot
         superclass.all(ALL_PROPERTIES_PATH, opts, filter)
       end
 
+      def get(property_name, opts={})
+        superclass.get(GET_PROPERTY_PATH, property_name, opts)
+      end
+
       def groups(opts={}, filter={})
         superclass.groups(ALL_GROUPS_PATH, opts, filter)
+      end
+
+      def get_group(group_name, opts={})
+        superclass.get_group(GET_GROUP_PATH, group_name, opts)
       end
 
       def create!(params={})

--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -26,7 +26,7 @@ module Hubspot
         filter_results(response, :groupName, filter[:include], filter[:exclude])
       end
 
-      def get(path, property_name, opts={})
+      def find(path, property_name, opts={})
         response = Hubspot::Connection.get_json(path, opts.merge({ property_name: property_name }))
       end
 
@@ -35,7 +35,7 @@ module Hubspot
         filter_results(response, :name, filter[:include], filter[:exclude])
       end
 
-      def get_group(path, group_name, opts={})
+      def find_group(path, group_name, opts={})
         response = Hubspot::Connection.get_json(path, opts.merge({ group_name: group_name }))
       end
 

--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -26,9 +26,17 @@ module Hubspot
         filter_results(response, :groupName, filter[:include], filter[:exclude])
       end
 
+      def get(path, property_name, opts={})
+        response = Hubspot::Connection.get_json(path, opts.merge({ property_name: property_name }))
+      end
+
       def groups(path, opts={}, filter={})
         response = Hubspot::Connection.get_json(path, opts)
         filter_results(response, :name, filter[:include], filter[:exclude])
+      end
+
+      def get_group(path, group_name, opts={})
+        response = Hubspot::Connection.get_json(path, opts.merge({ group_name: group_name }))
       end
 
       def create!(path, params={})

--- a/spec/fixtures/vcr_cassettes/company_properties/existing_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/existing_group.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/companies/groups/named/companyinformation
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:31:44 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745df422cb6cb730-AMS
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, max-age=0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 1e574e74-5a3c-4df3-9c69-6cfb58458c18
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499979'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '149'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2B3C57BAFA0B17129FF36E2FE9E9A2935BDF45A701000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=rJrmTMZxkR8J%2BwsiCRbDS88S6HFyWsy%2FLnGMSREx%2BpouGjq5IbAjdjjZOg8jtiijfV%2BYh2QK5%2FvAHSkuKFWz1mlbij%2FbkShqd0BI%2FZzTj4SyGke0cjBRu%2FyFrrZAfZUl"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: '{"name":"companyinformation","fulcrumPortalId":0,"fulcrumTimestamp":0,"displayName":"Company
+        information","displayOrder":1,"hubspotDefined":true}'
+  recorded_at: Mon, 05 Sep 2022 09:31:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/company_properties/existing_property.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/existing_property.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/domain
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:31:04 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '490'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745df325fd0db72a-AMS
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - f0de7a0a-dd04-4f8c-96ef-8a570a52f93c
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499981'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '149'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2BAD7370381E7ECE3A6DB247B2FF1485835AC45FBD000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=gvbEOcwjPzMxaj9vF2DYwSyTUIm2c3YzQjhIT2Jg3IuBvkf36k6UL7EvdZ%2FbFxSxwhrjl0U25QD0kURJrf%2F5YLGsexZv2agjm6iExmh91spu2wZ8f7F7vt85XhhLzjoN"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"domain","label":"Company Domain Name","description":"The domain
+        name of the company or organization","groupName":"companyinformation","type":"string","fieldType":"text","fieldLevelPermission":null,"hidden":false,"readOnlyDefinition":true,"formField":true,"displayOrder":9,"readOnlyValue":false,"mutableDefinitionNotDeletable":false,"favorited":false,"favoritedOrder":-1,"numberDisplayHint":null,"textDisplayHint":"domain_name","referencedObjectType":null,"deleted":null,"updatedAt":1653691894844,"externalOptionsReferenceType":null,"optionSortStrategy":null,"createdAt":1565059304024,"isCustomizedDefault":false,"optionsAreMutable":null,"searchTextAnalysisMode":null,"currencyPropertyName":null,"updatedUserId":null,"options":[],"calculated":false,"externalOptions":false,"displayMode":"current_value","showCurrencySymbol":null,"hubspotDefined":true,"createdUserId":null,"searchableInGlobalSearch":false,"hasUniqueValue":false}'
+  recorded_at: Mon, 05 Sep 2022 09:31:04 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/company_properties/non_existent_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/non_existent_group.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/companies/groups/named/this_does_not_exist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:31:44 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '186'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745df423d850b76c-AMS
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, max-age=0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 2fc682d7-69b4-49c4-8ba6-452d3472c51c
+      X-Hubspot-Notfound:
+      - 'true'
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499978'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '148'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2B084408627831E8C860E7A6FE944A68F81234BC28000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=D3VQp%2F78jNXCMEyPnorYxPQFJXvcppMjXY8xEafvHaFtLzJyIqeD%2F6HIaLYhKletvyjQ0ZXGCvedptIfbV9WiNSuzoOomjVE%2Fi026Vy04Ok7nDJPYbx0SIouO6TW8dl8"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: '{"status":"error","message":"Couldn''t find a Group with the given
+        name ''this_does_not_exist''.","correlationId":"2fc682d7-69b4-49c4-8ba6-452d3472c51c","groupsErrorCode":"GROUP_NOT_FOUND"}'
+  recorded_at: Mon, 05 Sep 2022 09:31:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/company_properties/non_existent_property.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/non_existent_property.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/this_does_not_exist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:31:04 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745df3271bd5b730-AMS
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 33c1bfb3-30b6-4b36-b8ce-b7c9100e25a4
+      X-Hubspot-Notfound:
+      - 'true'
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499980'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '148'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2BF7A4F51547C2532005087374CFB6C6E5DCEEF96B000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=bVSmiiojEQfKsIzpquwxjcrQZW9WtdmGcvVnwtbksGlen4ZXYB57AsGPcAGMNe7cFlqeP189Ug68ER%2BoExGesl83EBdFjsFfKH2IJ0Pl9TFxOq3nseIIMk8maVAP%2FFLU"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status":"error","message":"Couldn''t find a Property with the given
+        name ''this_does_not_exist''","correlationId":"33c1bfb3-30b6-4b36-b8ce-b7c9100e25a4","propertiesErrorCode":"PROPERTY_NOT_FOUND"}'
+  recorded_at: Mon, 05 Sep 2022 09:31:04 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/contact_properties/existing_group.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/existing_group.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/contacts/groups/named/contactinformation
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:09:55 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '145'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745dd42a9c35b70c-AMS
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, max-age=0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - fdf79bf0-501e-4cf7-8097-c8d94a637c38
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499991'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '147'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2B183234DD9610A3EFE73B22116E6A9A6BDFB20995000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=hpSEsBNB7slyZ9VYxX2ePXa79AVgSxDu2sQomE9M3Ln%2FAZYc32gU%2FZ3zFWDTWOcoBVe%2Fx9ARkRzXPD%2Fef5h8v9CjckwI5K37GrJuaqlrmyWcu1ecgZyL3MtOIwh5vpfS"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: '{"name":"contactinformation","fulcrumPortalId":0,"fulcrumTimestamp":0,"displayName":"Contact
+        information","displayOrder":0,"hubspotDefined":true}'
+  recorded_at: Mon, 05 Sep 2022 09:09:55 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/contact_properties/existing_property.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/existing_property.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/contacts/properties/named/full_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:09:47 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '451'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745dd3f848b5b8e4-AMS
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 73687713-9bc7-41d7-aed8-f7902402ac0d
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499993'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '149'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2BD37F8AEC5E32D39AF2DFE6DC01A51AA7A85AA5E1000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=gMMyOqldYzcW3kTqlj%2FknHu%2FVNZPiIMODDzyGFUoA6ILmrGZj9FHjlaC3CegV3KNX6rcd6DriY8qdO1tffYehJP72Z8t%2BYxku%2F3ZH2LPm8tSK0ZJCvgaAozQv2HPOM7e"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"full_name","label":"Full name","description":"","groupName":"contactinformation","type":"string","fieldType":"text","fieldLevelPermission":null,"options":[],"createdAt":1652135085834,"deleted":false,"updatedAt":1652135085834,"readOnlyDefinition":false,"formField":true,"displayOrder":-1,"readOnlyValue":false,"mutableDefinitionNotDeletable":false,"favorited":false,"favoritedOrder":-1,"calculated":false,"externalOptions":false,"displayMode":"current_value","showCurrencySymbol":false,"hubspotDefined":null,"hidden":false,"referencedObjectType":null,"externalOptionsReferenceType":null,"optionSortStrategy":null,"createdUserId":null,"searchableInGlobalSearch":false,"hasUniqueValue":false,"numberDisplayHint":"formatted","currencyPropertyName":null,"textDisplayHint":null,"optionsAreMutable":null,"searchTextAnalysisMode":null,"isCustomizedDefault":false,"updatedUserId":null}'
+  recorded_at: Mon, 05 Sep 2022 09:09:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/contact_properties/non-existent-property.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/non-existent-property.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/contacts/properties/named/this_does_not_exist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:09:47 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745dd3f93f1bb70c-AMS
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - cdd8f8c9-03bf-48f1-af08-1b3b11a9bad9
+      X-Hubspot-Notfound:
+      - 'true'
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499992'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '148'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2BD1DCD418DC7DC5199345F12CE55C48FD716C27A4000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=%2FovOpK3T%2BYQyGICnMW%2BHssdFsOl1K7hFnJ1DDvOblkYqsZ7YsWTJEXVURqIzuZm2NXwg3GEY9cVA1coBE8a%2BblS7hVmW9j4j%2B6CYf5bi6G3ScEOo2HIK2MdKy1Jre%2BbP"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status":"error","message":"Couldn''t find a Property with the given
+        name ''this_does_not_exist''","correlationId":"cdd8f8c9-03bf-48f1-af08-1b3b11a9bad9","propertiesErrorCode":"PROPERTY_NOT_FOUND"}'
+  recorded_at: Mon, 05 Sep 2022 09:09:47 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/contact_properties/non_existent_group.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/non_existent_group.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/contacts/groups/named/this_does_not_exist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:09:55 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '186'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745dd42bfcedb71f-AMS
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, max-age=0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 95f698b8-38af-4bf4-b9d4-d6b5c7bfb95d
+      X-Hubspot-Notfound:
+      - 'true'
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499990'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '146'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2B1A4F99C5FDA97A55047A877BAD8998A8DDA6BAE2000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=7m9354N1RnlArSXm5nIPoGOTqLV6h2DHzXnchl7QbKnAIfKLlp%2Bclp50Kok4ACNAMqoJz45ktS3JTIkZiVKaIecETc20qfUo0wxt8J5ahk%2FXmRieJOtuFS51laqxjhIH"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: '{"status":"error","message":"Couldn''t find a Group with the given
+        name ''this_does_not_exist''.","correlationId":"95f698b8-38af-4bf4-b9d4-d6b5c7bfb95d","groupsErrorCode":"GROUP_NOT_FOUND"}'
+  recorded_at: Mon, 05 Sep 2022 09:09:55 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/contact_properties/non_existent_property.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/non_existent_property.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 05 Sep 2022 09:09:47 GMT
+      - Mon, 05 Sep 2022 09:13:03 GMT
       Content-Type:
       - application/json;charset=utf-8
       Transfer-Encoding:
@@ -29,7 +29,7 @@ http_interactions:
       Connection:
       - keep-alive
       Cf-Ray:
-      - 745dd3f93f1bb70c-AMS
+      - 745dd8c11903b72a-AMS
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Vary:
@@ -39,27 +39,27 @@ http_interactions:
       Access-Control-Allow-Credentials:
       - 'false'
       X-Hubspot-Correlation-Id:
-      - cdd8f8c9-03bf-48f1-af08-1b3b11a9bad9
+      - 1f52f273-7b70-436b-aa37-cdc92883797f
       X-Hubspot-Notfound:
       - 'true'
       X-Hubspot-Ratelimit-Daily:
       - '500000'
       X-Hubspot-Ratelimit-Daily-Remaining:
-      - '499992'
+      - '499989'
       X-Hubspot-Ratelimit-Interval-Milliseconds:
       - '10000'
       X-Hubspot-Ratelimit-Max:
       - '150'
       X-Hubspot-Ratelimit-Remaining:
-      - '148'
+      - '149'
       X-Hubspot-Ratelimit-Secondly:
       - '15'
       X-Hubspot-Ratelimit-Secondly-Remaining:
       - '14'
       X-Trace:
-      - 2BD1DCD418DC7DC5199345F12CE55C48FD716C27A4000000000000000000
+      - 2BA6C773EACCE5B41E487AF341DF5BB732D8D63F86000000000000000000
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=%2FovOpK3T%2BYQyGICnMW%2BHssdFsOl1K7hFnJ1DDvOblkYqsZ7YsWTJEXVURqIzuZm2NXwg3GEY9cVA1coBE8a%2BblS7hVmW9j4j%2B6CYf5bi6G3ScEOo2HIK2MdKy1Jre%2BbP"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=6fnJkTywE%2FM7s%2FLHp61hbHK%2F26nx1JQntPMLPc%2BCm6Fi5LlNYNoeuG93BnLwz%2BPB8mh4jzODl%2BsxLe1Bid7DKXpHcv4bwcQiXvPfMO6SzOAFlsd65g9rORqemvKzsm0n"}],"group":"cf-nel","max_age":604800}'
       Nel:
       - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
       Server:
@@ -69,6 +69,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"status":"error","message":"Couldn''t find a Property with the given
-        name ''this_does_not_exist''","correlationId":"cdd8f8c9-03bf-48f1-af08-1b3b11a9bad9","propertiesErrorCode":"PROPERTY_NOT_FOUND"}'
-  recorded_at: Mon, 05 Sep 2022 09:09:47 GMT
+        name ''this_does_not_exist''","correlationId":"1f52f273-7b70-436b-aa37-cdc92883797f","propertiesErrorCode":"PROPERTY_NOT_FOUND"}'
+  recorded_at: Mon, 05 Sep 2022 09:13:02 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/deal_properties/existing_group.yml
+++ b/spec/fixtures/vcr_cassettes/deal_properties/existing_group.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/deals/groups/named/deal_revenue
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:25:27 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '151'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745deaedcb55b8e4-AMS
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, max-age=0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 3782811b-7077-476d-96b3-b30877328efc
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499983'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '149'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2BCD148A1A478810A348F4CE52716788440B2E3F28000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=9XyiAWjcntpogo5PO5miQxx4FOCqHPkkPST3JI16CCnaMCJYPYX3gHlP1f2l%2FfzIO5RNvLAMpHZFGxMXnCCZVeH8T9bcgXw%2FCZ%2B4%2BZHtSCYu5GjlO5MgRgZc6zCMVqKF"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: '{"name":"deal_revenue","fulcrumPortalId":8008758,"fulcrumTimestamp":1593475199999,"displayName":"Deal
+        revenue","displayOrder":-1,"hubspotDefined":true}'
+  recorded_at: Mon, 05 Sep 2022 09:25:27 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/deal_properties/existing_property.yml
+++ b/spec/fixtures/vcr_cassettes/deal_properties/existing_property.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/deals/properties/named/hs_acv
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:21:10 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '483'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745de4a5fc01b730-AMS
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 361386a8-3bc4-4308-9d2d-6e89cb45951e
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499988'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '149'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2B563459D36CA0D6D2F0237BB51FC8EAE7B0867765000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=DcFzvzz%2FsG1kYkZmYHjCSI7ZsLJ4qMezzNcwHeeQFYkAXk12rV6ykODoeYMLxFhU%2FXjABZWCiUWK8YFar4M4kNiryJWK3dYj7Mzu5dwavGvKeo3iRYFwTRl71LriY3Hz"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"hs_acv","label":"Annual contract value","description":"The
+        annual contract value (ACV) of this deal.","groupName":"deal_revenue","type":"number","fieldType":"number","fieldLevelPermission":null,"hidden":false,"deleted":null,"updatedAt":1653695359828,"createdAt":1593532658357,"readOnlyDefinition":true,"formField":false,"displayOrder":-1,"readOnlyValue":true,"mutableDefinitionNotDeletable":false,"favorited":false,"favoritedOrder":-1,"calculated":true,"externalOptions":false,"displayMode":"current_value","showCurrencySymbol":true,"hubspotDefined":true,"referencedObjectType":null,"externalOptionsReferenceType":null,"optionSortStrategy":null,"createdUserId":null,"searchableInGlobalSearch":false,"hasUniqueValue":false,"numberDisplayHint":null,"currencyPropertyName":"deal_currency_code","textDisplayHint":null,"optionsAreMutable":null,"searchTextAnalysisMode":null,"isCustomizedDefault":false,"updatedUserId":null,"options":[]}'
+  recorded_at: Mon, 05 Sep 2022 09:21:10 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/deal_properties/non_existent_group.yml
+++ b/spec/fixtures/vcr_cassettes/deal_properties/non_existent_group.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/deals/groups/named/this_does_not_exist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:25:27 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '186'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745deaeeda26b8b2-AMS
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, max-age=0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 53b54502-70f2-49ef-8a4a-ab338a94d871
+      X-Hubspot-Notfound:
+      - 'true'
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499982'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '148'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2BA1AB4CB59471EADD9B88E2F10494716CEE298DEC000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=dpE%2ByaV9508052l7P%2BgBZi5nIqOcOo69MldPlXc8yGer9kolzXixDMpS%2F5SODAFvY6FoL2Y9za77LC3y7j%2F0qE8ogn%2Fw6FD9NVLKPprymaDNbDwYpqHxYCkubAMQ7O1G"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: '{"status":"error","message":"Couldn''t find a Group with the given
+        name ''this_does_not_exist''.","correlationId":"53b54502-70f2-49ef-8a4a-ab338a94d871","groupsErrorCode":"GROUP_NOT_FOUND"}'
+  recorded_at: Mon, 05 Sep 2022 09:25:27 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/deal_properties/non_existent_property.yml
+++ b/spec/fixtures/vcr_cassettes/deal_properties/non_existent_property.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/properties/v1/deals/properties/named/this_does_not_exist
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 09:21:10 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 745de4a75f0eb8e4-AMS
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Credentials:
+      - 'false'
+      X-Hubspot-Correlation-Id:
+      - 2108a2d0-2785-4b4b-a28c-f731439a53eb
+      X-Hubspot-Notfound:
+      - 'true'
+      X-Hubspot-Ratelimit-Daily:
+      - '500000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '499987'
+      X-Hubspot-Ratelimit-Interval-Milliseconds:
+      - '10000'
+      X-Hubspot-Ratelimit-Max:
+      - '150'
+      X-Hubspot-Ratelimit-Remaining:
+      - '148'
+      X-Hubspot-Ratelimit-Secondly:
+      - '15'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '14'
+      X-Trace:
+      - 2B9EE3462CD22C78BF2630BED563BEA1F39F8ED25F000000000000000000
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Wza5KZDFCEaVF3cz3otIAcu%2BrQoIX3PCOJZoVIQRSFnRB5BG0iuK7npGuGh1b%2FKtrkODB%2FwILbE2Bx4DZJOdKp7ojhs%2BtXN87ep6jQ5%2Fs5pkm2uiXJHfYvbTllPrU1QX"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status":"error","message":"Couldn''t find a Property with the given
+        name ''this_does_not_exist''","correlationId":"2108a2d0-2785-4b4b-a28c-f731439a53eb","propertiesErrorCode":"PROPERTY_NOT_FOUND"}'
+  recorded_at: Mon, 05 Sep 2022 09:21:10 GMT
+recorded_with: VCR 6.1.0

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -111,12 +111,12 @@ RSpec.describe Hubspot::CompanyProperties do
       end
     end
 
-    describe '.get' do
+    describe '.find' do
       context 'existing property' do
         cassette 'company_properties/existing_property'
 
         it 'should return a company property by name if it exists' do
-          response = Hubspot::CompanyProperties.get('domain')
+          response = Hubspot::CompanyProperties.find('domain')
           expect(response['name']).to eq 'domain'
           expect(response['label']).to eq 'Company Domain Name'
         end
@@ -126,7 +126,7 @@ RSpec.describe Hubspot::CompanyProperties do
         cassette 'company_properties/non_existent_property'
 
         it 'should return an error for a missing property' do
-          expect{ Hubspot::CompanyProperties.get('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+          expect{ Hubspot::CompanyProperties.find('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end
@@ -352,12 +352,12 @@ RSpec.describe Hubspot::CompanyProperties do
       end
     end
 
-    describe '.get_group' do
+    describe '.find_group' do
       context 'existing group' do
         cassette 'company_properties/existing_group'
 
         it 'should return a company property group by name if it exists' do
-          response = Hubspot::CompanyProperties.get_group('companyinformation')
+          response = Hubspot::CompanyProperties.find_group('companyinformation')
           expect(response['name']).to eq 'companyinformation'
           expect(response['displayName']).to eq 'Company information'
         end
@@ -367,7 +367,7 @@ RSpec.describe Hubspot::CompanyProperties do
         cassette 'company_properties/non_existent_group'
 
         it 'should return an error for a missing group' do
-          expect{ Hubspot::CompanyProperties.get_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+          expect{ Hubspot::CompanyProperties.find_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -111,6 +111,26 @@ RSpec.describe Hubspot::CompanyProperties do
       end
     end
 
+    describe '.get' do
+      context 'existing property' do
+        cassette 'company_properties/existing_property'
+
+        it 'should return a company property by name if it exists' do
+          response = Hubspot::CompanyProperties.get('domain')
+          expect(response['name']).to eq 'domain'
+          expect(response['label']).to eq 'Company Domain Name'
+        end
+      end
+
+      context 'non-existent property' do
+        cassette 'company_properties/non_existent_property'
+
+        it 'should return an error for a missing property' do
+          expect{ Hubspot::CompanyProperties.get('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+        end
+      end
+    end
+
     describe ".create!" do
       it "creates a company property" do
         VCR.use_cassette("company_properties/create_property") do
@@ -328,6 +348,26 @@ RSpec.describe Hubspot::CompanyProperties do
             Hubspot::CompanyProperties.delete!("instagram_handle")
             Hubspot::CompanyProperties.delete!("fax_number")
           end
+        end
+      end
+    end
+
+    describe '.get_group' do
+      context 'existing group' do
+        cassette 'company_properties/existing_group'
+
+        it 'should return a company property group by name if it exists' do
+          response = Hubspot::CompanyProperties.get_group('companyinformation')
+          expect(response['name']).to eq 'companyinformation'
+          expect(response['displayName']).to eq 'Company information'
+        end
+      end
+
+      context 'non-existent group' do
+        cassette 'company_properties/non_existent_group'
+
+        it 'should return an error for a missing group' do
+          expect{ Hubspot::CompanyProperties.get_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -50,7 +50,7 @@ describe Hubspot::ContactProperties do
       end
 
       context 'non-existent property' do
-        cassette 'contact_properties/non-existent-property'
+        cassette 'contact_properties/non_existent_property'
 
         it 'should return an error for a missing property' do
           expect{ Hubspot::ContactProperties.get('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -38,6 +38,26 @@ describe Hubspot::ContactProperties do
       end
     end
 
+    describe '.get' do
+      context 'existing property' do
+        cassette 'contact_properties/existing_property'
+
+        it 'should return a contact property by name if it exists' do
+          response = Hubspot::ContactProperties.get('full_name')
+          expect(response['name']).to eq 'full_name'
+          expect(response['label']).to eq 'Full name'
+        end
+      end
+
+      context 'non-existent property' do
+        cassette 'contact_properties/non-existent-property'
+
+        it 'should return an error for a missing property' do
+          expect{ Hubspot::ContactProperties.get('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+        end
+      end
+    end
+
     let(:params) { {
       'name'                          => 'my_new_property',
       'label'                         => 'This is my new property',
@@ -137,6 +157,26 @@ describe Hubspot::ContactProperties do
         it 'should return groups that were not excluded' do
           response = Hubspot::ContactProperties.groups({}, { exclude: groups })
           response.each { |p| expect(groups.include?(p['name'])).to be false }
+        end
+      end
+    end
+
+    describe '.get' do
+      context 'existing group' do
+        cassette 'contact_properties/existing_group'
+
+        it 'should return a contact property by name if it exists' do
+          response = Hubspot::ContactProperties.get_group('contactinformation')
+          expect(response['name']).to eq 'contactinformation'
+          expect(response['displayName']).to eq 'Contact information'
+        end
+      end
+
+      context 'non-existent group' do
+        cassette 'contact_properties/non_existent_group'
+
+        it 'should return an error for a missing group' do
+          expect{ Hubspot::ContactProperties.get_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -161,7 +161,7 @@ describe Hubspot::ContactProperties do
       end
     end
 
-    describe '.get' do
+    describe '.get_group' do
       context 'existing group' do
         cassette 'contact_properties/existing_group'
 

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -38,12 +38,12 @@ describe Hubspot::ContactProperties do
       end
     end
 
-    describe '.get' do
+    describe '.find' do
       context 'existing property' do
         cassette 'contact_properties/existing_property'
 
         it 'should return a contact property by name if it exists' do
-          response = Hubspot::ContactProperties.get('full_name')
+          response = Hubspot::ContactProperties.find('full_name')
           expect(response['name']).to eq 'full_name'
           expect(response['label']).to eq 'Full name'
         end
@@ -53,7 +53,7 @@ describe Hubspot::ContactProperties do
         cassette 'contact_properties/non_existent_property'
 
         it 'should return an error for a missing property' do
-          expect{ Hubspot::ContactProperties.get('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+          expect{ Hubspot::ContactProperties.find('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end
@@ -161,12 +161,12 @@ describe Hubspot::ContactProperties do
       end
     end
 
-    describe '.get_group' do
+    describe '.find_group' do
       context 'existing group' do
         cassette 'contact_properties/existing_group'
 
         it 'should return a contact property by name if it exists' do
-          response = Hubspot::ContactProperties.get_group('contactinformation')
+          response = Hubspot::ContactProperties.find_group('contactinformation')
           expect(response['name']).to eq 'contactinformation'
           expect(response['displayName']).to eq 'Contact information'
         end
@@ -176,7 +176,7 @@ describe Hubspot::ContactProperties do
         cassette 'contact_properties/non_existent_group'
 
         it 'should return an error for a missing group' do
-          expect{ Hubspot::ContactProperties.get_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+          expect{ Hubspot::ContactProperties.find_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -37,6 +37,26 @@ describe Hubspot::DealProperties do
         end
       end
     end
+    
+    describe '.get' do
+      context 'existing property' do
+        cassette 'deal_properties/existing_property'
+
+        it 'should return a deal property by name if it exists' do
+          response = Hubspot::DealProperties.get('hs_acv')
+          expect(response['name']).to eq 'hs_acv'
+          expect(response['label']).to eq 'Annual contract value'
+        end
+      end
+
+      context 'non-existent property' do
+        cassette 'deal_properties/non_existent_property'
+
+        it 'should return an error for a missing property' do
+          expect{ Hubspot::DealProperties.get('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+        end
+      end
+    end
 
     let(:params) { {
       'name'                          => "my_new_property_#{SecureRandom.hex}",
@@ -136,6 +156,26 @@ describe Hubspot::DealProperties do
         it 'should return groups that were not excluded' do
           response = Hubspot::DealProperties.groups({}, { exclude: groups })
           response.each { |p| expect(groups.include?(p['name'])).to be false }
+        end
+      end
+    end
+
+    describe '.get_group' do
+      context 'existing group' do
+        cassette 'deal_properties/existing_group'
+
+        it 'should return a deal property by name if it exists' do
+          response = Hubspot::DealProperties.get_group('deal_revenue')
+          expect(response['name']).to eq 'deal_revenue'
+          expect(response['displayName']).to eq 'Deal revenue'
+        end
+      end
+
+      context 'non-existent group' do
+        cassette 'deal_properties/non_existent_group'
+
+        it 'should return an error for a missing group' do
+          expect{ Hubspot::DealProperties.get_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -38,12 +38,12 @@ describe Hubspot::DealProperties do
       end
     end
     
-    describe '.get' do
+    describe '.find' do
       context 'existing property' do
         cassette 'deal_properties/existing_property'
 
         it 'should return a deal property by name if it exists' do
-          response = Hubspot::DealProperties.get('hs_acv')
+          response = Hubspot::DealProperties.find('hs_acv')
           expect(response['name']).to eq 'hs_acv'
           expect(response['label']).to eq 'Annual contract value'
         end
@@ -53,7 +53,7 @@ describe Hubspot::DealProperties do
         cassette 'deal_properties/non_existent_property'
 
         it 'should return an error for a missing property' do
-          expect{ Hubspot::DealProperties.get('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+          expect{ Hubspot::DealProperties.find('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end
@@ -160,12 +160,12 @@ describe Hubspot::DealProperties do
       end
     end
 
-    describe '.get_group' do
+    describe '.find_group' do
       context 'existing group' do
         cassette 'deal_properties/existing_group'
 
         it 'should return a deal property by name if it exists' do
-          response = Hubspot::DealProperties.get_group('deal_revenue')
+          response = Hubspot::DealProperties.find_group('deal_revenue')
           expect(response['name']).to eq 'deal_revenue'
           expect(response['displayName']).to eq 'Deal revenue'
         end
@@ -175,7 +175,7 @@ describe Hubspot::DealProperties do
         cassette 'deal_properties/non_existent_group'
 
         it 'should return an error for a missing group' do
-          expect{ Hubspot::DealProperties.get_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
+          expect{ Hubspot::DealProperties.find_group('this_does_not_exist') }.to raise_error(Hubspot::NotFoundError)
         end
       end
     end


### PR DESCRIPTION
The HS API allows for requesting of single properties and groups, but this functionality has yet to be implemented in ruby. This PR adds this functionality for the currently supported properties: contact, company and deal.

I think I've added tests correctly, but please let me know if not. I might also have overlooked the reasoning as to why this isn't already implemented, or maybe I missed where it /is/ implemented. I'd appreciate you taking a look and consider merging it for the released gem if appropriate.

Thanks!