### PR TITLE
Update required ruby version

### DIFF
--- a/hubspot-api-ruby.gemspec
+++ b/hubspot-api-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "changelog_uri" => "https://github.com/captaincontrat/hubspot-api-ruby/blob/master/History.md"
   }
 
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 2.7"
 
   # Add runtime dependencies here
   s.add_runtime_dependency "activesupport", ">= 4.2.2"


### PR DESCRIPTION
As noted in #11

Even if it should work under 2.5, we test against 2.7, so I think it's safer that way.