### PR TITLE
Introduce Deal search

### DIFF
--- a/lib/hubspot/deal.rb
+++ b/lib/hubspot/deal.rb
@@ -148,7 +148,7 @@ module Hubspot
             params: {},
             body: {
               **params,
-              properties: BASE_PROPERTIES | properties.compact,
+              properties: properties.compact,
               filters: (opts[:filters].presence || []),
               sorts: opts[:sorts].presence || default_sorts
             }

--- a/lib/hubspot/deal.rb
+++ b/lib/hubspot/deal.rb
@@ -22,7 +22,7 @@ module Hubspot
 
     def initialize(response_hash)
       @portal_id = response_hash["portalId"]
-      @deal_id = response_hash["dealId"]
+      @deal_id = response_hash["id"] || response_hash["dealId"]
       # Search API does not support returning associations. There's an open issue on HubSpot's side here: https://community.hubspot.com/t5/HubSpot-Ideas/Retrieving-Associated-IDs-via-HubSpot-APIv3-SearchAPI/idi-p/966730
       @company_ids = response_hash.fetch("associations", {}).fetch("associatedCompanyIds", nil)
       @vids = response_hash.fetch("associations", {}).fetch("associatedVids", nil)

--- a/lib/hubspot/deal.rb
+++ b/lib/hubspot/deal.rb
@@ -116,7 +116,6 @@ module Hubspot
       def all(opts = {})
         path = ALL_DEALS_PATH
 
-        opts[:includeAssociations] = true # Needed for initialize to work
         response = Hubspot::Connection.get_json(path, opts)
 
         result = {}
@@ -148,7 +147,6 @@ module Hubspot
             params: {},
             body: {
               **params,
-              includeAssociations: true,
               properties: properties.compact,
               filters: (opts[:filters].presence || []),
               sorts: opts[:sorts].presence || default_sorts

--- a/lib/hubspot/deal.rb
+++ b/lib/hubspot/deal.rb
@@ -23,8 +23,9 @@ module Hubspot
     def initialize(response_hash)
       @portal_id = response_hash["portalId"]
       @deal_id = response_hash["dealId"]
-      @company_ids = response_hash["associations"]["associatedCompanyIds"]
-      @vids = response_hash["associations"]["associatedVids"]
+      # Search API does not support returning associations. There's an open issue on HubSpot's side here: https://community.hubspot.com/t5/HubSpot-Ideas/Retrieving-Associated-IDs-via-HubSpot-APIv3-SearchAPI/idi-p/966730
+      @company_ids = response_hash.fetch("associations", {}).fetch("associatedCompanyIds", nil)
+      @vids = response_hash.fetch("associations", {}).fetch("associatedVids", nil)
       @properties = Hubspot::Utils.properties_to_hash(response_hash["properties"])
     end
 

--- a/lib/hubspot/deal.rb
+++ b/lib/hubspot/deal.rb
@@ -148,6 +148,7 @@ module Hubspot
             params: {},
             body: {
               **params,
+              includeAssociations: true,
               properties: properties.compact,
               filters: (opts[:filters].presence || []),
               sorts: opts[:sorts].presence || default_sorts

--- a/lib/hubspot/utils.rb
+++ b/lib/hubspot/utils.rb
@@ -4,7 +4,7 @@ module Hubspot
       # Parses the hubspot properties format into a key-value hash
       def properties_to_hash(props)
         newprops = HashWithIndifferentAccess.new
-        props.each { |k, v| newprops[k] = v["value"] }
+        props.each { |k, v| newprops[k] = v.is_a?(Hash) ? v["value"] : v }
         newprops
       end
 


### PR DESCRIPTION
Hi, thanks for maintaining this awesome gem

I wanted to be able to search deals by name and pipeline, and this functionality was missing from the gem (AFAICT), even though it looked supported by the objects v3 search API 

Originally found this discussion here: https://community.hubspot.com/t5/APIs-Integrations/How-can-I-do-a-search-for-all-deals-in-the-default-pipeline/m-p/793111 which led to the v3 search docs here: https://developers.hubspot.com/docs/api/crm/search

I've got this working, can be searched and filtered like so:

```ruby
deals = Hubspot::Deal.find_by_search(
  properties: %w(dealname amount closedate dealstage),
  filters: [
    { propertyName: 'pipeline', 'operator': 'EQ', value: '12345' },
    { propertyName: 'dealname', 'operator': 'CONTAINS_TOKEN', value: 'MyDealName' },
  ],
)
```

Unfortunately the search API seems to return results in a very different format from the v1 API that was currently being used to fetch deals, so I had to strip out some of the associations from being required for deal init.

Let me know if you would accept a PR like this, what tests you would need, anything else you'd change about the way I'm doing this lmk