### PR TITLE
Fix console and make it useful

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,10 +1,16 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
+
+# Setup ENV variables
+require "dotenv"
+Dotenv.load(".env.development.local", ".env.development", ".env.local", ".env")
+
 require "hubspot-api-ruby"
 
 # Include Byebug for debugging
 require "byebug"
+
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -13,8 +19,11 @@ require "byebug"
 # require "pry"
 # Pry.start
 
-# Configure with the demo key by default
-Hubspot.configure(hapikey: 'demo')
+Hubspot.configure(
+  access_token: ENV.fetch("HUBSPOT_ACCESS_TOKEN"),
+  portal_id: ENV.fetch("HUBSPOT_PORTAL_ID"),
+  logger: Logger.new(STDOUT)
+)
 
 require "irb"
 IRB.start(__FILE__)

--- a/hubspot-api-ruby.gemspec
+++ b/hubspot-api-ruby.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("byebug")
   s.add_development_dependency("faker")
   s.add_development_dependency("factory_bot")
+  s.add_development_dependency("irb")
 end


### PR DESCRIPTION
Fixes the following warning/error in Ruby 4+

```
bin/console:28: warning: irb used to be loaded from the standard
library, but is not part of the default gems since Ruby 4.0.0.
You can add irb to your Gemfile or gemspec to fix this error.
```

Moreover, makes `bin/console` actually useful. To use it, configure
`HUBSPOT_ACCESS_TOKEN` and `HUBSPOT_PORTAL_ID` in `.env*` files
assuming `development` as the environment.