### PR TITLE
Fix pagination for contacts

### DIFF
--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -17,10 +17,9 @@ class Hubspot::Contact < Hubspot::Resource
   class << self
     def all(opts = {})
       Hubspot::PagedCollection.new(opts) do |options, after, limit|
-        response = Hubspot::Connection.get_json(
-          ALL_PATH,
-          options.merge('limit' => limit, 'offset' => after, 'offset_param' => 'after')
-        )
+        request_options = options.merge(limit:)
+        request_options[:after] = after if after.present?
+        response = Hubspot::Connection.get_json(ALL_PATH, request_options)
 
         contacts = response['results'].map { |result| from_result(result) }
         after = response.dig('paging', 'next', 'after')

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_a_limit_respects_the_limit.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_a_limit_respects_the_limit.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=1&offset=&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_a_limit_returns_a_collection.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_a_limit_returns_a_collection.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=1&offset=&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_an_offset_has_an_offset.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_an_offset_has_an_offset.yml
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Mon, 20 Apr 2026 13:19:03 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25&offset=216669749577&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?after=216669749577&limit=25
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_an_offset_identifies_if_there_are_more_resources.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_an_offset_identifies_if_there_are_more_resources.yml
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Mon, 20 Apr 2026 13:19:04 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25&offset=216670492303&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?after=216670492303&limit=25
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_an_offset_returns_a_collection.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_with_an_offset_returns_a_collection.yml
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Mon, 20 Apr 2026 13:19:02 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25&offset=216677834118&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?after=216677834118&limit=25
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_without_options_has_an_offset.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_without_options_has_an_offset.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25&offset=&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_without_options_identifies_if_there_are_more_resources.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_without_options_identifies_if_there_are_more_resources.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25&offset=&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_without_options_returns_a_collection.yml
+++ b/spec/fixtures/vcr_cassettes/Hubspot_Contact_all_without_options_returns_a_collection.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25&offset=&offset_param=after
+    uri: https://api.hubapi.com/crm/v3/objects/contacts?limit=25
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
The newer APIs for contacts only use the `after` param for pagination, s. https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/contacts/guide and https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/contacts/get-contacts for more details.