### PR TITLE
Fix ID parsing for contacts API

### DIFF
--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -22,7 +22,9 @@ class Hubspot::Contact < Hubspot::Resource
           options.merge('limit' => limit, 'offset' => after, 'offset_param' => 'after')
         )
 
-        contacts = response['results'].map { |result| from_result(result) }
+        contacts = response['results'].map do |result| 
+          from_result result, id_field: Hubspot::Resource.id_field 
+        end
         after = response.dig('paging', 'next', 'after')
         [contacts, after, after.present?]
       end

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -9,7 +9,7 @@ module Hubspot
     self.update_method = "put"
 
     class << self
-      def from_result(result)
+      def from_result(result, id_field: self.id_field)
         resource = new(result[id_field])
         resource.send(:initialize_from, result.with_indifferent_access)
         resource
@@ -55,9 +55,12 @@ module Hubspot
       @changes = HashWithIndifferentAccess.new
       @properties = HashWithIndifferentAccess.new
 
-      if id_or_properties.is_a?(Integer) || id_or_properties.nil?
+      case id_or_properties
+      when Integer, NilClass
         @id = id_or_properties
-      elsif id_or_properties.is_a?(Hash)
+      when String
+        @id = Integer id_or_properties
+      when Hash
         @id = id_or_properties.delete(id_field) || id_or_properties.delete(:id)
 
         add_accessors(id_or_properties.keys)


### PR DESCRIPTION
v3 and newer no longer return a `vid` field. Instead, they return a resource `id`. As `id_field` is configured per resource API this extends the API of `from_result` such that a `id_param` can be provided at the call side.

Also, the `id` is not a number but a string so add support for parsing string IDs.