### PR TITLE
Update and extend GHA test matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,8 +6,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.4.9'
-          - '4.0.2'
+          - '3.3'
+          - '3.4'
+          - '4.0'
         active_support:
           - 'active_support_8.1.x'
     steps:

--- a/hubspot-api-ruby.gemspec
+++ b/hubspot-api-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "changelog_uri" => "https://github.com/captaincontrat/hubspot-api-ruby/blob/master/History.md"
   }
 
-  s.required_ruby_version = ">= 3.2"
+  s.required_ruby_version = ">= 3.3"
 
   # Add runtime dependencies here
   s.add_runtime_dependency "activesupport", ">= 4.2.2"


### PR DESCRIPTION
@fonji Based on my recent PRs I thought this might be useful to stop myself from filing PRs that ignore the minimum Ruby version. Note: according to https://www.ruby-lang.org/en/downloads/branches/ Ruby 3.2.x is EOL. 