### PR TITLE
Fix contact property accessors

### DIFF
--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -106,6 +106,16 @@ class Hubspot::Contact < Hubspot::Resource
     end
   end
 
+  def [](name)
+    if changes.key? name
+      @changes[name]
+    else
+      name_property = @properties[name]
+
+      name_property.is_a?(Hash) ? name_property["value"] : name_property
+    end
+  end
+
   def name
     [firstname, lastname].compact.join(' ')
   end

--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -107,13 +107,11 @@ class Hubspot::Contact < Hubspot::Resource
   end
 
   def [](name)
-    if changes.key? name
-      @changes[name]
-    else
-      name_property = @properties[name]
+    return @changes[name] if changes.key? name
 
-      name_property.is_a?(Hash) ? name_property["value"] : name_property
-    end
+    name_property = @properties[name]
+
+    name_property.is_a?(Hash) ? name_property['value'] : name_property
   end
 
   def name

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -230,7 +230,7 @@ module Hubspot
       singleton_class.instance_eval do
         keys.each do |k|
           # Define a getter
-          define_method(k) { @changes[k.to_sym] || @properties.dig(k, 'value') }
+          define_method(k) { self[k] }
 
           # Define a setter
           define_method("#{k}=") do |v|
@@ -247,9 +247,9 @@ module Hubspot
         add_accessors([attr])
 
         # Call the new setter
-        return send(method_name, arguments[0])
+        send(method_name, arguments[0])
       elsif @properties.key?(method_name)
-        return @properties[method_name]['value']
+        self[method_name]
       else
         super
       end

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -234,7 +234,7 @@ module Hubspot
 
           # Define a setter
           define_method("#{k}=") do |v|
-            @changes[k.to_sym] = v
+            @changes[k] = v
           end
         end
       end


### PR DESCRIPTION
The JSON response shape has changed between Contacts v1 and v3+ which now results in exceptions when using the various convenience methods to access properties. This DRYs up the property access logic and overloads it for Contact resources specifically to fix the issue.