### PR TITLE
Fix/freeze literal string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 # Add dependencies to hubspot-api-ruby.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 # Add dependencies to hubspot-api-ruby.gemspec
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+#
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## unreleased
+
+Fix frozen string literal warning, add magical comment to freeze string literals everywhere
+
 ## 0.23.0
 
 BREAKING CHANGE : requires ruby 3.3+, as [ruby 3.2 is EOL](https://www.ruby-lang.org/en/downloads/branches/), we're not testing against olders versions

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'rubygems'
 require 'bundler'

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 

--- a/hubspot-api-ruby.gemspec
+++ b/hubspot-api-ruby.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Gem::Specification.new do |s|
   s.name = "hubspot-api-ruby"
   s.version = "0.23.0"

--- a/hubspot-api-ruby.gemspec
+++ b/hubspot-api-ruby.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name = "hubspot-api-ruby"
   s.version = "0.23.0"

--- a/lib/hubspot-api-ruby.rb
+++ b/lib/hubspot-api-ruby.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support'
 require 'active_support/core_ext'
 require 'httparty'

--- a/lib/hubspot-api-ruby.rb
+++ b/lib/hubspot-api-ruby.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'active_support'
 require 'active_support/core_ext'
 require 'httparty'

--- a/lib/hubspot/association.rb
+++ b/lib/hubspot/association.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hubspot::Association
   OBJECT_TARGET_TO_CLASS = {
     "Contact" => Hubspot::Contact,

--- a/lib/hubspot/association.rb
+++ b/lib/hubspot/association.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Hubspot::Association
   OBJECT_TARGET_TO_CLASS = {
     "Contact" => Hubspot::Contact,

--- a/lib/hubspot/blog.rb
+++ b/lib/hubspot/blog.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   #
   # HubSpot Contacts API

--- a/lib/hubspot/blog.rb
+++ b/lib/hubspot/blog.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   #
   # HubSpot Contacts API

--- a/lib/hubspot/collection.rb
+++ b/lib/hubspot/collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hubspot::Collection
   def initialize(opts = {}, &block)
     @options = opts

--- a/lib/hubspot/collection.rb
+++ b/lib/hubspot/collection.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Hubspot::Collection
   def initialize(opts = {}, &block)
     @options = opts

--- a/lib/hubspot/company.rb
+++ b/lib/hubspot/company.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hubspot::Company < Hubspot::Resource
   self.id_field = "companyId"
   self.property_name_field = "name"

--- a/lib/hubspot/company.rb
+++ b/lib/hubspot/company.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Hubspot::Company < Hubspot::Resource
   self.id_field = "companyId"
   self.property_name_field = "name"

--- a/lib/hubspot/company_properties.rb
+++ b/lib/hubspot/company_properties.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class CompanyProperties < Properties
 

--- a/lib/hubspot/company_properties.rb
+++ b/lib/hubspot/company_properties.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class CompanyProperties < Properties
 

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'logger'
 require 'hubspot/connection'
 

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'logger'
 require 'hubspot/connection'
 

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -90,10 +90,10 @@ module Hubspot
           params["portal_id"] = Hubspot::Config.portal_id if path =~ /:portal_id/
         end
 
-        params.each do |k,v|
-          if path.match(":#{k}")
-            path.gsub!(":#{k}", CGI.escape(v.to_s))
-            params.delete(k)
+        params.each do |key, value|
+          if path.match(":#{key}")
+            path = path.gsub(":#{key}", CGI.escape(value.to_s))
+            params.delete(key)
           end
         end
         raise(Hubspot::MissingInterpolation.new("Interpolation not resolved")) if path =~ /:/

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -41,10 +41,10 @@ module Hubspot
           verb,
           url,
           body: options[:body].to_json,
-          headers: { "Content-Type" => "application/json" },
+          headers: { 'Content-Type' => 'application/json' },
           format: :json,
           read_timeout: read_timeout(options),
-          open_timeout: open_timeout(options),
+          open_timeout: open_timeout(options)
         )
 
         log_request_and_response(url, response, options[:body])
@@ -65,10 +65,11 @@ module Hubspot
         return response if response.success?
 
         raise(Hubspot::NotFoundError.new(response)) if response.not_found?
+
         raise(Hubspot::RequestError.new(response))
       end
 
-      def log_request_and_response(uri, response, body=nil)
+      def log_request_and_response(uri, response, body = nil)
         Hubspot::Config.logger.info(<<~MSG)
           Hubspot: #{uri}.
           Body: #{body}.
@@ -76,7 +77,7 @@ module Hubspot
         MSG
       end
 
-      def generate_url(path, params={}, options={})
+      def generate_url(path, params = {}, options = {})
         if Hubspot::Config.access_token.present?
           options[:hapikey] = false
         else
@@ -85,11 +86,11 @@ module Hubspot
         path = path.clone
         params = params.clone
         base_url = options[:base_url] || Hubspot::Config.base_url
-        params["hapikey"] = Hubspot::Config.hapikey unless options[:hapikey] == false
+        params['hapikey'] = Hubspot::Config.hapikey unless options[:hapikey] == false
 
-        if path =~ /:portal_id/
+        if /:portal_id/.match?(path)
           Hubspot::Config.ensure! :portal_id
-          params["portal_id"] = Hubspot::Config.portal_id if path =~ /:portal_id/
+          params['portal_id'] = Hubspot::Config.portal_id if /:portal_id/.match?(path)
         end
 
         params.each do |key, value|
@@ -98,13 +99,13 @@ module Hubspot
             params.delete(key)
           end
         end
-        raise(Hubspot::MissingInterpolation.new("Interpolation not resolved")) if path =~ /:/
+        raise(Hubspot::MissingInterpolation.new('Interpolation not resolved')) if /:/.match?(path)
 
-        query = params.map do |k,v|
-          v.is_a?(Array) ? v.map { |value| param_string(k,value) } : param_string(k,v)
-        end.join("&")
+        query = params.map do |k, v|
+          v.is_a?(Array) ? v.map { |value| param_string(k, value) } : param_string(k, v)
+        end.join('&')
 
-        path += path.include?('?') ? '&' : "?" if query.present?
+        path += path.include?('?') ? '&' : '?' if query.present?
         base_url + path + query
       end
 
@@ -113,13 +114,14 @@ module Hubspot
         value.is_a?(Time) ? (value.to_i * 1000) : CGI.escape(value.to_s)
       end
 
-      def param_string(key,value)
+      def param_string(key, value)
         case key
         when /range/
-          raise "Value must be a range" unless value.is_a?(Range)
+          raise 'Value must be a range' unless value.is_a?(Range)
+
           "#{key}=#{converted_value(value.begin)}&#{key}=#{converted_value(value.end)}"
         when /^batch_(.*)$/
-          key = $1.gsub(/(_.)/) { |w| w.last.upcase }
+          key = ::Regexp.last_match(1).gsub(/(_.)/) { |w| w.last.upcase }
           "#{key}=#{converted_value(value)}"
         else
           "#{key}=#{converted_value(value)}"
@@ -148,7 +150,7 @@ module Hubspot
     def self.trigger(path, opts)
       url = generate_url(path, opts[:params], { hapikey: true })
       headers = (opts[:headers] || {}).merge('content-type': 'application/json')
-      post(url, body: opts[:body].to_json, headers: headers)
+      post(url, body: opts[:body].to_json, headers:)
     end
   end
 end

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -90,7 +90,7 @@ module Hubspot
 
         if /:portal_id/.match?(path)
           Hubspot::Config.ensure! :portal_id
-          params['portal_id'] = Hubspot::Config.portal_id if /:portal_id/.match?(path)
+          params['portal_id'] = Hubspot::Config.portal_id
         end
 
         params.each do |key, value|

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Hubspot
   class Connection
     include HTTParty

--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hubspot::Contact < Hubspot::Resource
   self.id_field = 'vid'
   self.update_method = 'post'

--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Hubspot::Contact < Hubspot::Resource
   self.id_field = 'vid'
   self.update_method = 'post'
@@ -22,8 +23,8 @@ class Hubspot::Contact < Hubspot::Resource
         request_options[:after] = after if after.present?
         response = Hubspot::Connection.get_json(ALL_PATH, request_options)
 
-        contacts = response['results'].map do |result| 
-          from_result result, id_field: Hubspot::Resource.id_field 
+        contacts = response['results'].map do |result|
+          from_result result, id_field: Hubspot::Resource.id_field
         end
         after = response.dig('paging', 'next', 'after')
         [contacts, after, after.present?]

--- a/lib/hubspot/contact_list.rb
+++ b/lib/hubspot/contact_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   #
   # HubSpot Contact lists API

--- a/lib/hubspot/contact_list.rb
+++ b/lib/hubspot/contact_list.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   #
   # HubSpot Contact lists API

--- a/lib/hubspot/contact_properties.rb
+++ b/lib/hubspot/contact_properties.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class ContactProperties < Properties
 

--- a/lib/hubspot/contact_properties.rb
+++ b/lib/hubspot/contact_properties.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class ContactProperties < Properties
 

--- a/lib/hubspot/conversation_thread.rb
+++ b/lib/hubspot/conversation_thread.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/conversation_thread.rb
+++ b/lib/hubspot/conversation_thread.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/custom_event.rb
+++ b/lib/hubspot/custom_event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/custom_event.rb
+++ b/lib/hubspot/custom_event.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/deal.rb
+++ b/lib/hubspot/deal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/deal.rb
+++ b/lib/hubspot/deal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/deal_pipeline.rb
+++ b/lib/hubspot/deal_pipeline.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/deal_pipeline.rb
+++ b/lib/hubspot/deal_pipeline.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/deal_properties.rb
+++ b/lib/hubspot/deal_properties.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class DealProperties < Properties
 

--- a/lib/hubspot/deal_properties.rb
+++ b/lib/hubspot/deal_properties.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class DealProperties < Properties
 

--- a/lib/hubspot/deprecator.rb
+++ b/lib/hubspot/deprecator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class Deprecator
     def self.build(version: "1.0")

--- a/lib/hubspot/deprecator.rb
+++ b/lib/hubspot/deprecator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class Deprecator
     def self.build(version: "1.0")

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/event.rb
+++ b/lib/hubspot/event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/event.rb
+++ b/lib/hubspot/event.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/exceptions.rb
+++ b/lib/hubspot/exceptions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class RequestError < StandardError
     attr_accessor :response

--- a/lib/hubspot/exceptions.rb
+++ b/lib/hubspot/exceptions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class RequestError < StandardError
     attr_accessor :response

--- a/lib/hubspot/file.rb
+++ b/lib/hubspot/file.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 require 'base64'
 require 'pp'

--- a/lib/hubspot/file.rb
+++ b/lib/hubspot/file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 require 'base64'
 require 'pp'

--- a/lib/hubspot/form.rb
+++ b/lib/hubspot/form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   #
   # HubSpot Form API

--- a/lib/hubspot/form.rb
+++ b/lib/hubspot/form.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   #
   # HubSpot Form API

--- a/lib/hubspot/meeting.rb
+++ b/lib/hubspot/meeting.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/meeting.rb
+++ b/lib/hubspot/meeting.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/oauth.rb
+++ b/lib/hubspot/oauth.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'httparty'
 
 module Hubspot

--- a/lib/hubspot/oauth.rb
+++ b/lib/hubspot/oauth.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'httparty'
 
 module Hubspot

--- a/lib/hubspot/owner.rb
+++ b/lib/hubspot/owner.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   #
   # HubSpot Owners API

--- a/lib/hubspot/owner.rb
+++ b/lib/hubspot/owner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   #
   # HubSpot Owners API

--- a/lib/hubspot/paged_collection.rb
+++ b/lib/hubspot/paged_collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Hubspot::PagedCollection < Hubspot::Collection
   attr_accessor :offset, :limit
 

--- a/lib/hubspot/paged_collection.rb
+++ b/lib/hubspot/paged_collection.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class Hubspot::PagedCollection < Hubspot::Collection
   attr_accessor :offset, :limit
 

--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class Properties
 

--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class Properties
 

--- a/lib/hubspot/railtie.rb
+++ b/lib/hubspot/railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot-api-ruby'
 require 'rails'
 module Hubspot

--- a/lib/hubspot/railtie.rb
+++ b/lib/hubspot/railtie.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot-api-ruby'
 require 'rails'
 module Hubspot

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class Resource
     class_attribute :id_field, instance_writer: false

--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class Resource
     class_attribute :id_field, instance_writer: false

--- a/lib/hubspot/subscription.rb
+++ b/lib/hubspot/subscription.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class Subscription
     SUBSCRIPTIONS_PATH = '/email/public/v1/subscriptions'

--- a/lib/hubspot/subscription.rb
+++ b/lib/hubspot/subscription.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class Subscription
     SUBSCRIPTIONS_PATH = '/email/public/v1/subscriptions'

--- a/lib/hubspot/task.rb
+++ b/lib/hubspot/task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/task.rb
+++ b/lib/hubspot/task.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/ticket.rb
+++ b/lib/hubspot/ticket.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/ticket.rb
+++ b/lib/hubspot/ticket.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hubspot/utils'
 
 module Hubspot

--- a/lib/hubspot/ticket_properties.rb
+++ b/lib/hubspot/ticket_properties.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class TicketProperties < Properties
     CREATE_PROPERTY_PATH = '/crm/v3/properties/ticket'

--- a/lib/hubspot/ticket_properties.rb
+++ b/lib/hubspot/ticket_properties.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class TicketProperties < Properties
     CREATE_PROPERTY_PATH = '/crm/v3/properties/ticket'

--- a/lib/hubspot/topic.rb
+++ b/lib/hubspot/topic.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   #
   # HubSpot Topics API

--- a/lib/hubspot/topic.rb
+++ b/lib/hubspot/topic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   #
   # HubSpot Topics API

--- a/lib/hubspot/utils.rb
+++ b/lib/hubspot/utils.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   class Utils
     class << self

--- a/lib/hubspot/utils.rb
+++ b/lib/hubspot/utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   class Utils
     class << self

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 FactoryBot.define do
   factory :company, class: Hubspot::Company do

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 FactoryBot.define do
   factory :contact, class: 'Hubspot::Contact' do
     to_create { |instance| instance.save }

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryBot.define do
   factory :contact, class: 'Hubspot::Contact' do
     to_create { |instance| instance.save }

--- a/spec/lib/hubspot-ruby_spec.rb
+++ b/spec/lib/hubspot-ruby_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot do
   describe ".configure" do
     it "delegates .configure to Hubspot::Config.configure" do

--- a/spec/lib/hubspot-ruby_spec.rb
+++ b/spec/lib/hubspot-ruby_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot do
   describe ".configure" do
     it "delegates .configure to Hubspot::Config.configure" do

--- a/spec/lib/hubspot/association_spec.rb
+++ b/spec/lib/hubspot/association_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::Association do
   let(:portal_id) { 62515 }
   let(:company) { create :company }

--- a/spec/lib/hubspot/association_spec.rb
+++ b/spec/lib/hubspot/association_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::Association do
   let(:portal_id) { 62515 }
   let(:company) { create :company }

--- a/spec/lib/hubspot/blog_spec.rb
+++ b/spec/lib/hubspot/blog_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'timecop'
 
 describe Hubspot do

--- a/spec/lib/hubspot/blog_spec.rb
+++ b/spec/lib/hubspot/blog_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'timecop'
 
 describe Hubspot do

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::CompanyProperties do
   describe '.add_default_parameters' do
     let(:opts) { {} }

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::CompanyProperties do
   describe '.add_default_parameters' do
     let(:opts) { {} }

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::Company do
 
   it_behaves_like "a saveable resource", :company do

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::Company do
 
   it_behaves_like "a saveable resource", :company do

--- a/spec/lib/hubspot/config_spec.rb
+++ b/spec/lib/hubspot/config_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Config do
   describe ".configure" do
     it "sets the access token config" do

--- a/spec/lib/hubspot/config_spec.rb
+++ b/spec/lib/hubspot/config_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::Config do
   describe ".configure" do
     it "sets the access token config" do

--- a/spec/lib/hubspot/connection_spec.rb
+++ b/spec/lib/hubspot/connection_spec.rb
@@ -1,68 +1,69 @@
 # frozen_string_literal: true
-describe Hubspot::Connection do
-  describe ".get_json" do
-    it "returns the parsed response from the GET request" do
-      path = "/some/path"
-      body = { key: "value" }
 
-      stub_request(:get, "https://api.hubapi.com/some/path").to_return(status: 200, body: JSON.generate(body))
+describe Hubspot::Connection do
+  describe '.get_json' do
+    it 'returns the parsed response from the GET request' do
+      path = '/some/path'
+      body = { key: 'value' }
+
+      stub_request(:get, 'https://api.hubapi.com/some/path').to_return(status: 200, body: JSON.generate(body))
 
       result = Hubspot::Connection.get_json(path, {})
-      expect(result).to eq({ "key" => "value" })
+      expect(result).to eq({ 'key' => 'value' })
     end
   end
 
-  describe ".post_json" do
-    it "returns the parsed response from the POST request" do
-      path = "/some/path"
-      body = { id: 1, name: "ABC" }
+  describe '.post_json' do
+    it 'returns the parsed response from the POST request' do
+      path = '/some/path'
+      body = { id: 1, name: 'ABC' }
 
-      stub_request(:post, "https://api.hubapi.com/some/path?name=ABC").to_return(status: 200, body: JSON.generate(body))
+      stub_request(:post, 'https://api.hubapi.com/some/path?name=ABC').to_return(status: 200, body: JSON.generate(body))
 
-      result = Hubspot::Connection.post_json(path, params: { name: "ABC" })
-      expect(result).to eq({ "id" => 1, "name" => "ABC" })
+      result = Hubspot::Connection.post_json(path, params: { name: 'ABC' })
+      expect(result).to eq({ 'id' => 1, 'name' => 'ABC' })
     end
   end
 
-  describe ".delete_json" do
-    it "returns the response from the DELETE request" do
-      path = "/some/path"
+  describe '.delete_json' do
+    it 'returns the response from the DELETE request' do
+      path = '/some/path'
 
-      stub_request(:delete, "https://api.hubapi.com/some/path").to_return(status: 204, body: JSON.generate({}))
+      stub_request(:delete, 'https://api.hubapi.com/some/path').to_return(status: 204, body: JSON.generate({}))
 
       result = Hubspot::Connection.delete_json(path, {})
       expect(result.code).to eq(204)
     end
   end
 
-  describe ".put_json" do
-    it "issues a PUT request and returns the parsed body" do
-      path = "/some/path"
+  describe '.put_json' do
+    it 'issues a PUT request and returns the parsed body' do
+      path = '/some/path'
       update_options = { params: {}, body: {} }
 
-      stub_request(:put, "https://api.hubapi.com/some/path").to_return(status: 200, body: JSON.generate(vid: 123))
+      stub_request(:put, 'https://api.hubapi.com/some/path').to_return(status: 200, body: JSON.generate(vid: 123))
 
       response = Hubspot::Connection.put_json(path, update_options)
 
       assert_requested(
         :put,
-        "https://api.hubapi.com/some/path",
-         {
-           body: "{}",
-           headers: { "Content-Type" => "application/json" },
-         }
+        'https://api.hubapi.com/some/path',
+        {
+          body: '{}',
+          headers: { 'Content-Type' => 'application/json' }
+        }
       )
-      expect(response).to eq({ "vid" => 123 })
+      expect(response).to eq({ 'vid' => 123 })
     end
 
-    it "logs information about the request and response" do
-      path = "/some/path"
+    it 'logs information about the request and response' do
+      path = '/some/path'
       update_options = { params: {}, body: {} }
 
       logger = stub_logger
 
-      stub_request(:put, "https://api.hubapi.com/some/path").to_return(status: 200,
-                                                                       body: JSON.generate("response body"))
+      stub_request(:put, 'https://api.hubapi.com/some/path').to_return(status: 200,
+                                                                       body: JSON.generate('response body'))
 
       Hubspot::Connection.put_json(path, update_options)
 
@@ -73,46 +74,46 @@ describe Hubspot::Connection do
       MSG
     end
 
-    it "raises when the request fails" do
-      path = "/some/path"
+    it 'raises when the request fails' do
+      path = '/some/path'
       update_options = { params: {}, body: {} }
 
-      stub_request(:put, "https://api.hubapi.com/some/path").to_return(status: 401)
+      stub_request(:put, 'https://api.hubapi.com/some/path').to_return(status: 401)
 
-      expect {
+      expect do
         Hubspot::Connection.put_json(path, update_options)
-      }.to raise_error(Hubspot::RequestError)
+      end.to raise_error(Hubspot::RequestError)
     end
   end
 
-  describe ".patch_json" do
-    it "issues a PATCH request and returns the parsed body" do
-      path = "/some/path"
+  describe '.patch_json' do
+    it 'issues a PATCH request and returns the parsed body' do
+      path = '/some/path'
       update_options = { params: {}, body: {} }
 
-      stub_request(:patch, "https://api.hubapi.com/some/path").to_return(status: 200, body: JSON.generate(vid: 123))
+      stub_request(:patch, 'https://api.hubapi.com/some/path').to_return(status: 200, body: JSON.generate(vid: 123))
 
       response = Hubspot::Connection.patch_json(path, update_options)
 
       assert_requested(
         :patch,
-        "https://api.hubapi.com/some/path",
+        'https://api.hubapi.com/some/path',
         {
-          body: "{}",
-          headers: { "Content-Type" => "application/json" },
+          body: '{}',
+          headers: { 'Content-Type' => 'application/json' }
         }
       )
-      expect(response).to eq({ "vid" => 123 })
+      expect(response).to eq({ 'vid' => 123 })
     end
 
-    it "logs information about the request and response" do
-      path = "/some/path"
+    it 'logs information about the request and response' do
+      path = '/some/path'
       update_options = { params: {}, body: {} }
 
       logger = stub_logger
 
-      stub_request(:patch, "https://api.hubapi.com/some/path").to_return(status: 200,
-                                                                       body: JSON.generate("response body"))
+      stub_request(:patch, 'https://api.hubapi.com/some/path').to_return(status: 200,
+                                                                         body: JSON.generate('response body'))
 
       Hubspot::Connection.patch_json(path, update_options)
 
@@ -123,99 +124,109 @@ describe Hubspot::Connection do
       MSG
     end
 
-    it "raises when the request fails" do
-      path = "/some/path"
+    it 'raises when the request fails' do
+      path = '/some/path'
       update_options = { params: {}, body: {} }
 
-      stub_request(:patch, "https://api.hubapi.com/some/path").to_return(status: 401)
+      stub_request(:patch, 'https://api.hubapi.com/some/path').to_return(status: 401)
 
-      expect {
+      expect do
         Hubspot::Connection.patch_json(path, update_options)
-      }.to raise_error(Hubspot::RequestError)
+      end.to raise_error(Hubspot::RequestError)
     end
   end
 
   context 'private methods' do
-    describe ".generate_url" do
-      let(:path) { "/test/:email/profile" }
-      let(:params) { { email: "test" } }
-      let(:options) { {} }
+    describe '.generate_url' do
       subject { Hubspot::Connection.send(:generate_url, path, params, options) }
 
+      let(:path) { '/test/:email/profile' }
+      let(:params) { { email: 'test' } }
+      let(:options) { {} }
+
       it "doesn't modify params" do
-        expect { subject }.to_not change{params}
+        expect { subject }.not_to(change { params })
       end
 
-      context "with a portal_id param" do
-        let(:path) { "/test/:portal_id/profile" }
+      context 'with a portal_id param' do
+        let(:path) { '/test/:portal_id/profile' }
         let(:params) { {} }
 
         before do
-          Hubspot.configure(access_token: ENV.fetch("HUBSPOT_ACCESS_TOKEN"), portal_id: ENV.fetch("HUBSPOT_PORTAL_ID"))
+          Hubspot.configure(access_token: ENV.fetch('HUBSPOT_ACCESS_TOKEN'), portal_id: ENV.fetch('HUBSPOT_PORTAL_ID'))
         end
 
-        it { should == "https://api.hubapi.com/test/#{ENV.fetch('HUBSPOT_PORTAL_ID')}/profile" }
+        it { is_expected.to eq("https://api.hubapi.com/test/#{ENV.fetch('HUBSPOT_PORTAL_ID')}/profile") }
       end
 
       context "when configure hasn't been called" do
         before { Hubspot::Config.reset! }
-        it "raises a config exception" do
+
+        it 'raises a config exception' do
           expect { subject }.to raise_error Hubspot::ConfigurationError
         end
       end
 
-      context "with interpolations but no params" do
+      context 'with interpolations but no params' do
         let(:params) { {} }
 
-        it "raises an interpolation exception" do
-          expect{ subject }.to raise_error Hubspot::MissingInterpolation
+        it 'raises an interpolation exception' do
+          expect { subject }.to raise_error Hubspot::MissingInterpolation
         end
       end
 
-      context "with an interpolated param" do
-        let(:params) { { email: "email@address.com" } }
-        it { should == "https://api.hubapi.com/test/email%40address.com/profile" }
+      context 'with an interpolated param' do
+        let(:params) { { email: 'email@address.com' } }
+
+        it { is_expected.to eq('https://api.hubapi.com/test/email%40address.com/profile') }
       end
 
-      context "with multiple interpolated params" do
-        let(:path) { "/test/:email/:id/profile" }
-        let(:params) { { email: "email@address.com", id: 1234 } }
-        it { should == "https://api.hubapi.com/test/email%40address.com/1234/profile" }
+      context 'with multiple interpolated params' do
+        let(:path) { '/test/:email/:id/profile' }
+        let(:params) { { email: 'email@address.com', id: 1234 } }
+
+        it { is_expected.to eq('https://api.hubapi.com/test/email%40address.com/1234/profile') }
       end
 
-      context "with query params" do
-        let(:params) { { email: "email@address.com", id: 1234 } }
-        it { should == "https://api.hubapi.com/test/email%40address.com/profile?id=1234" }
+      context 'with query params' do
+        let(:params) { { email: 'email@address.com', id: 1234 } }
 
-        context "containing a time" do
+        it { is_expected.to eq('https://api.hubapi.com/test/email%40address.com/profile?id=1234') }
+
+        context 'containing a time' do
           let(:start_time) { Time.now }
-          let(:params) { { email: "email@address.com", id: 1234, start: start_time } }
-          it { should == "https://api.hubapi.com/test/email%40address.com/profile?id=1234&start=#{start_time.to_i * 1000}" }
+          let(:params) { { email: 'email@address.com', id: 1234, start: start_time } }
+
+          it { is_expected.to eq("https://api.hubapi.com/test/email%40address.com/profile?id=1234&start=#{start_time.to_i * 1000}") }
         end
 
-        context "containing a range" do
+        context 'containing a range' do
           let(:start_time) { Time.now }
           let(:end_time) { Time.now + 1.year }
-          let(:params) { { email: "email@address.com", id: 1234, created__range: start_time..end_time  } }
-          it { should == "https://api.hubapi.com/test/email%40address.com/profile?id=1234&created__range=#{start_time.to_i * 1000}&created__range=#{end_time.to_i * 1000}" }
+          let(:params) { { email: 'email@address.com', id: 1234, created__range: start_time..end_time } }
+
+          it { is_expected.to eq("https://api.hubapi.com/test/email%40address.com/profile?id=1234&created__range=#{start_time.to_i * 1000}&created__range=#{end_time.to_i * 1000}") }
         end
 
-        context "containing an array of strings" do
-          let(:path) { "/test/emails" }
-          let(:params) { { batch_email: %w(email1@example.com email2@example.com) } }
-          it { should == "https://api.hubapi.com/test/emails?email=email1%40example.com&email=email2%40example.com" }
+        context 'containing an array of strings' do
+          let(:path) { '/test/emails' }
+          let(:params) { { batch_email: %w[email1@example.com email2@example.com] } }
+
+          it { is_expected.to eq('https://api.hubapi.com/test/emails?email=email1%40example.com&email=email2%40example.com') }
         end
       end
 
-      context "with options" do
-        let(:options) { { base_url: "https://cool.com", access_token: false } }
-        it { should == "https://cool.com/test/test/profile" }
+      context 'with options' do
+        let(:options) { { base_url: 'https://cool.com', access_token: false } }
+
+        it { is_expected.to eq('https://cool.com/test/test/profile') }
       end
 
-      context "passing Array as parameters for batch mode, key is prefixed with batch_" do
+      context 'passing Array as parameters for batch mode, key is prefixed with batch_' do
         let(:path) { Hubspot::ContactList::LISTS_PATH }
-        let(:params) { { batch_list_id: [1,2,3] } }
-        it { should == "https://api.hubapi.com/crm/v3/lists?listId=1&listId=2&listId=3" }
+        let(:params) { { batch_list_id: [1, 2, 3] } }
+
+        it { is_expected.to eq('https://api.hubapi.com/crm/v3/lists?listId=1&listId=2&listId=3') }
       end
     end
   end
@@ -229,11 +240,12 @@ end
 
 describe Hubspot::EventConnection do
   describe '.trigger' do
+    subject { described_class.trigger(path, options) }
+
     let(:path) { '/path' }
     let(:options) { { params: {} } }
     let(:headers) { nil }
 
-    subject { described_class.trigger(path, options) }
     before { allow(described_class).to receive(:get).and_return(true) }
 
     it 'calls get with a custom url' do
@@ -243,11 +255,11 @@ describe Hubspot::EventConnection do
 
     context 'with more options' do
       let(:headers) { { 'User-Agent' => 'something' } }
-      let(:options) { { params: {}, headers: headers } }
+      let(:options) { { params: {}, headers: } }
 
       it 'supports headers' do
         subject
-        expect(described_class).to have_received(:get).with('https://track.hubspot.com/path', body: nil, headers: headers)
+        expect(described_class).to have_received(:get).with('https://track.hubspot.com/path', body: nil, headers:)
       end
     end
   end

--- a/spec/lib/hubspot/connection_spec.rb
+++ b/spec/lib/hubspot/connection_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Connection do
   describe ".get_json" do
     it "returns the parsed response from the GET request" do

--- a/spec/lib/hubspot/contact_list_spec.rb
+++ b/spec/lib/hubspot/contact_list_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::ContactList do
   # uncomment if you need to create test data in your panel.
   # note that sandboxes have a limit of 10 dynamic lists

--- a/spec/lib/hubspot/contact_list_spec.rb
+++ b/spec/lib/hubspot/contact_list_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::ContactList do
   # uncomment if you need to create test data in your panel.
   # note that sandboxes have a limit of 10 dynamic lists

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::ContactProperties do
   describe '.add_default_parameters' do
     let(:opts) { {} }

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::ContactProperties do
   describe '.add_default_parameters' do
     let(:opts) { {} }

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::Contact do
   it_behaves_like 'a saveable resource', :contact do
     def set_property(contact)

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::Contact do
   it_behaves_like 'a saveable resource', :contact do
     def set_property(contact)

--- a/spec/lib/hubspot/conversation_thread_spec.rb
+++ b/spec/lib/hubspot/conversation_thread_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::ConversationThread do
   describe 'find' do
     let(:thread_id) { 3_176_297_853 }

--- a/spec/lib/hubspot/conversation_thread_spec.rb
+++ b/spec/lib/hubspot/conversation_thread_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::ConversationThread do
   describe 'find' do
     let(:thread_id) { 3_176_297_853 }

--- a/spec/lib/hubspot/custom_event_spec.rb
+++ b/spec/lib/hubspot/custom_event_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::CustomEvent do
   before do
     Hubspot.configure(access_token: ENV.fetch("HUBSPOT_ACCESS_TOKEN"), portal_id: ENV.fetch("HUBSPOT_PORTAL_ID"),

--- a/spec/lib/hubspot/custom_event_spec.rb
+++ b/spec/lib/hubspot/custom_event_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::CustomEvent do
   before do
     Hubspot.configure(access_token: ENV.fetch("HUBSPOT_ACCESS_TOKEN"), portal_id: ENV.fetch("HUBSPOT_PORTAL_ID"),

--- a/spec/lib/hubspot/deal_pipeline_spec.rb
+++ b/spec/lib/hubspot/deal_pipeline_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::DealPipeline do
 
   describe ".find" do

--- a/spec/lib/hubspot/deal_pipeline_spec.rb
+++ b/spec/lib/hubspot/deal_pipeline_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::DealPipeline do
 
   describe ".find" do

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::DealProperties do
   describe '.add_default_parameters' do
     let(:opts) { {} }
@@ -38,7 +39,7 @@ describe Hubspot::DealProperties do
         end
       end
     end
-    
+
     describe '.find' do
       context 'existing property' do
         cassette 'deal_properties/existing_property'

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::DealProperties do
   describe '.add_default_parameters' do
     let(:opts) { {} }

--- a/spec/lib/hubspot/deal_spec.rb
+++ b/spec/lib/hubspot/deal_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::Deal do
   let(:portal_id) { ENV.fetch("HUBSPOT_PORTAL_ID").to_i }
   let(:company) { Hubspot::Company.create(name: SecureRandom.hex) }

--- a/spec/lib/hubspot/deal_spec.rb
+++ b/spec/lib/hubspot/deal_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Deal do
   let(:portal_id) { ENV.fetch("HUBSPOT_PORTAL_ID").to_i }
   let(:company) { Hubspot::Company.create(name: SecureRandom.hex) }

--- a/spec/lib/hubspot/deprecator_spec.rb
+++ b/spec/lib/hubspot/deprecator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::Deprecator do
   describe ".build" do
     it "returns an instance of ActiveSupport::Deprecation" do

--- a/spec/lib/hubspot/deprecator_spec.rb
+++ b/spec/lib/hubspot/deprecator_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::Deprecator do
   describe ".build" do
     it "returns an instance of ActiveSupport::Deprecation" do

--- a/spec/lib/hubspot/engagement_spec.rb
+++ b/spec/lib/hubspot/engagement_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Engagement do
   let(:contact) { Hubspot::Contact.create("#{SecureRandom.hex}@hubspot.com") }
   let(:engagement) { Hubspot::EngagementNote.create!(contact.id, "foo") }

--- a/spec/lib/hubspot/engagement_spec.rb
+++ b/spec/lib/hubspot/engagement_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::Engagement do
   let(:contact) { Hubspot::Contact.create("#{SecureRandom.hex}@hubspot.com") }
   let(:engagement) { Hubspot::EngagementNote.create!(contact.id, "foo") }

--- a/spec/lib/hubspot/event_spec.rb
+++ b/spec/lib/hubspot/event_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Event do
   let(:portal_id) { ENV.fetch("HUBSPOT_PORTAL_ID") }
   let(:sent_portal_id) { portal_id }

--- a/spec/lib/hubspot/event_spec.rb
+++ b/spec/lib/hubspot/event_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::Event do
   let(:portal_id) { ENV.fetch("HUBSPOT_PORTAL_ID") }
   let(:sent_portal_id) { portal_id }

--- a/spec/lib/hubspot/file_spec.rb
+++ b/spec/lib/hubspot/file_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::File do
   let(:example_file_hash) do
     VCR.use_cassette('file_example') do

--- a/spec/lib/hubspot/file_spec.rb
+++ b/spec/lib/hubspot/file_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::File do
   let(:example_file_hash) do
     VCR.use_cassette('file_example') do

--- a/spec/lib/hubspot/form_spec.rb
+++ b/spec/lib/hubspot/form_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Form do
   let(:example_form_hash) do
     VCR.use_cassette('form_example') do

--- a/spec/lib/hubspot/form_spec.rb
+++ b/spec/lib/hubspot/form_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::Form do
   let(:example_form_hash) do
     VCR.use_cassette('form_example') do

--- a/spec/lib/hubspot/meeting_spec.rb
+++ b/spec/lib/hubspot/meeting_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::Meeting do
 
   let(:hubspot_owner_id) do

--- a/spec/lib/hubspot/meeting_spec.rb
+++ b/spec/lib/hubspot/meeting_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::Meeting do
 
   let(:hubspot_owner_id) do

--- a/spec/lib/hubspot/owner_spec.rb
+++ b/spec/lib/hubspot/owner_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::Owner do
   let(:example_owners) do
     VCR.use_cassette('owner_example') do

--- a/spec/lib/hubspot/owner_spec.rb
+++ b/spec/lib/hubspot/owner_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Owner do
   let(:example_owners) do
     VCR.use_cassette('owner_example') do

--- a/spec/lib/hubspot/properties_spec.rb
+++ b/spec/lib/hubspot/properties_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hubspot
   describe Properties do
     let(:params) { { 'name'                          => 'amount_of_new_money_lined_up',

--- a/spec/lib/hubspot/properties_spec.rb
+++ b/spec/lib/hubspot/properties_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hubspot
   describe Properties do
     let(:params) { { 'name'                          => 'amount_of_new_money_lined_up',

--- a/spec/lib/hubspot/resource_spec.rb
+++ b/spec/lib/hubspot/resource_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 RSpec.describe Hubspot::Resource do
   describe '#new' do

--- a/spec/lib/hubspot/task_spec.rb
+++ b/spec/lib/hubspot/task_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::Task do
   describe 'create!' do
     subject(:new_task) do

--- a/spec/lib/hubspot/task_spec.rb
+++ b/spec/lib/hubspot/task_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::Task do
   describe 'create!' do
     subject(:new_task) do

--- a/spec/lib/hubspot/ticket_properties_spec.rb
+++ b/spec/lib/hubspot/ticket_properties_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::TicketProperties do
   describe '.create' do
     context 'with all valid parameters' do

--- a/spec/lib/hubspot/ticket_properties_spec.rb
+++ b/spec/lib/hubspot/ticket_properties_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::TicketProperties do
   describe '.create' do
     context 'with all valid parameters' do

--- a/spec/lib/hubspot/ticket_spec.rb
+++ b/spec/lib/hubspot/ticket_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.describe Hubspot::Ticket do
   describe 'create!' do
     subject(:new_ticket) do

--- a/spec/lib/hubspot/ticket_spec.rb
+++ b/spec/lib/hubspot/ticket_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe Hubspot::Ticket do
   describe 'create!' do
     subject(:new_ticket) do

--- a/spec/lib/hubspot/utils_spec.rb
+++ b/spec/lib/hubspot/utils_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 describe Hubspot::Utils do
   API_HEADERS = { Authorization: "Bearer #{ENV.fetch('HUBSPOT_ACCESS_TOKEN')}" }.freeze
 

--- a/spec/lib/hubspot/utils_spec.rb
+++ b/spec/lib/hubspot/utils_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe Hubspot::Utils do
   API_HEADERS = { Authorization: "Bearer #{ENV.fetch('HUBSPOT_ACCESS_TOKEN')}" }.freeze
 

--- a/spec/shared_examples/saveable_resource.rb
+++ b/spec/shared_examples/saveable_resource.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.shared_examples_for "a saveable resource" do |factory_name|
   describe '#save' do
     context 'with a new resource' do

--- a/spec/shared_examples/saveable_resource.rb
+++ b/spec/shared_examples/saveable_resource.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples_for "a saveable resource" do |factory_name|
   describe '#save' do
     context 'with a new resource' do

--- a/spec/shared_examples/updateable_resource.rb
+++ b/spec/shared_examples/updateable_resource.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.shared_examples_for "an updateable resource" do |factory_name|
   describe '.update' do
     context 'with an existing resource' do

--- a/spec/shared_examples/updateable_resource.rb
+++ b/spec/shared_examples/updateable_resource.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.shared_examples_for "an updateable resource" do |factory_name|
   describe '.update' do
     context 'with an existing resource' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 RSPEC_ROOT = File.dirname(__FILE__)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 RSPEC_ROOT = File.dirname(__FILE__)

--- a/spec/support/cassette_helper.rb
+++ b/spec/support/cassette_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CassetteHelper
   def self.extended(base)
     base.around do |spec|

--- a/spec/support/cassette_helper.rb
+++ b/spec/support/cassette_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CassetteHelper
   def self.extended(base)
     base.around do |spec|

--- a/spec/support/hubspot_api_helpers.rb
+++ b/spec/support/hubspot_api_helpers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module HubspotApiHelpers
   def hubspot_api_url(path)
     URI.join(Hubspot::Config.base_url, path)

--- a/spec/support/hubspot_api_helpers.rb
+++ b/spec/support/hubspot_api_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module HubspotApiHelpers
   def hubspot_api_url(path)
     URI.join(Hubspot::Config.base_url, path)

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "vcr"
 
 def vcr_record_mode

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "vcr"
 
 def vcr_record_mode


### PR DESCRIPTION
Fixes `hubspot-api-ruby-0.22.1/lib/hubspot/connection.rb:95: warning: literal string will be frozen in the future`
Adds magical comments to ensure it does not happen again
Lints changed files